### PR TITLE
Better UoM support

### DIFF
--- a/src/main/resources/ESH-INF/thing/channels.xml
+++ b/src/main/resources/ESH-INF/thing/channels.xml
@@ -73,17 +73,17 @@
     </channel-type>
 
     <channel-type id="temperature">
-        <item-type>Number</item-type>
+        <item-type>Number:Temperature</item-type>
         <label>Temperature</label>
-        <description>Current temperature in degree Celsius</description>
+        <description>Current temperature</description>
         <category>Temperature</category>
-        <state pattern="%.1f °C" readOnly="true"></state>
+        <state pattern="%.1f %unit%" readOnly="true"></state>
     </channel-type>
 
     <channel-type id="humidity">
-        <item-type>Number</item-type>
+        <item-type>Number:Dimensionless</item-type>
         <label>Humidity</label>
-        <description>Relative humidity level in percentages</description>
+        <description>Relative humidity</description>
         <category>Humidity</category>
         <state min="0" max="100" step="1" pattern="%d %%" readOnly="true"></state>
     </channel-type>
@@ -103,46 +103,46 @@
     </channel-type>
 
     <channel-type id="pressure">
-        <item-type>Number</item-type>
+        <item-type>Number:Pressure</item-type>
         <label>Pressure</label>
-        <description>Barometric value in hPa.</description>
+        <description>Barometric pressure</description>
         <category>Pressure</category>
-        <state min="0" max="2000" step="1" pattern="%d hPa." readOnly="true"></state>
+        <state min="0" max="2000" step="1" pattern="%d %unit%" readOnly="true"></state>
     </channel-type>
 
     <channel-type id="windspeed">
-        <item-type>Number</item-type>
+        <item-type>Number:Speed</item-type>
         <label>Wind Speed</label>
-        <description>Average wind speed in meters per second</description>
-        <state pattern="%d %unit% m/s" readOnly="true"></state>
+        <description>Average wind speed</description>
+        <state pattern="%d %unit%" readOnly="true"></state>
     </channel-type>
 
     <channel-type id="winddirection">
-        <item-type>Number</item-type>
+        <item-type>Number:Angle</item-type>
         <label>Wind Direction</label>
-        <description>Wind direction in degrees</description>
-        <state min="0" max="360" step="1" readOnly="true"></state>
+        <description>Wind direction</description>
+        <state pattern="%d %unit%" min="0" max="360" step="1" readOnly="true"></state>
     </channel-type>
     
     <channel-type id="brightness">
-        <item-type>Number</item-type>
+        <item-type>Number:Illuminance</item-type>
         <label>Brightness</label>
-        <description>brightness in klx</description>
-        <state pattern="%d %unit% klx" min="0" max="100" readOnly="true"></state>
+        <description>brightness</description>
+        <state pattern="%d %unit%" min="0" max="100" readOnly="true"></state>
     </channel-type>
     
     <channel-type id="dusk">
-        <item-type>Number</item-type>
+        <item-type>Number:Illuminance</item-type>
         <label>Dusk</label>
-        <description>brightness in lx</description>
-        <state  min="0" max="500" pattern="%d %unit% lx" readOnly="true" />
+        <description>brightness</description>
+        <state  min="0" max="500" pattern="%d %unit%" readOnly="true" />
 
     </channel-type>
     
     <channel-type id="illumination">
         <item-type>Number:Illuminance</item-type>
         <label>Dusk</label>
-        <description>Illumination in lux</description>
+        <description>Illumination</description>
         <state pattern="%d %unit%" readOnly="true" />
     </channel-type>
     


### PR DESCRIPTION
Remove hardcoded Unit of Measurements, and qualify `item-type`s accordingly.

Make sure the binding returns values in the base unit (lux, not kilolux, for example) - the code is not up-to-date so I can't do that.