### PR TITLE
Add valance channels and request update after stop.

### DIFF
--- a/src/main/java/org/openhab/binding/openwms/config/OpenWMSBindingConstants.java
+++ b/src/main/java/org/openhab/binding/openwms/config/OpenWMSBindingConstants.java
@@ -78,6 +78,8 @@ public class OpenWMSBindingConstants {
     // List of all Channel ids
     public static final String CHANNEL_1 = "channel1";
     public static final String CHANNEL_SHUTTER = "shutter";
+    public static final String CHANNEL_VALANCE1 = "valance1";
+    public static final String CHANNEL_VALANCE2 = "valance2";
     public static final String CHANNEL_DIMMINGLEVEL = "dimminglevel";
     public static final String CHANNEL_BRIGHTNESS = "brightness";
     public static final String CHANNEL_DUSK = "dusk";

--- a/src/main/java/org/openhab/binding/openwms/internal/OpenWMSHandler.java
+++ b/src/main/java/org/openhab/binding/openwms/internal/OpenWMSHandler.java
@@ -66,7 +66,7 @@ public class OpenWMSHandler extends BaseThingHandler implements DeviceMessageLis
                 String t = getThing().getThingTypeUID().getId().toUpperCase();
                 logger.debug("Thing: ", t);
 
-                Map<String, String> msg = OpenWMSMessageFactory.createMessage(command.toString(), thing);
+                Map<String, String> msg = OpenWMSMessageFactory.createMessage(command.toString(), thing, channelUID);
                 // String tt = getThing().g.getThingTypeUID().getId().toUpperCase();
                 // .convertPacketType(getThing().getThingTypeUID().getId().toUpperCase());
 
@@ -98,7 +98,7 @@ public class OpenWMSHandler extends BaseThingHandler implements DeviceMessageLis
             if ((boolean) getThing().getConfiguration().getProperties().get("ignoreConfig") != true) {
                 // Limitüberwachung einschalten und Limits setzen (falls der Parameter 'IgnoreConfig' = false)
                 befehl = "SETLIMITS";
-                Map<String, String> msg = OpenWMSMessageFactory.createMessage(befehl, thing);
+                Map<String, String> msg = OpenWMSMessageFactory.createMessage(befehl, thing, null);
                 for (Entry<String, String> entry : msg.entrySet()) {
                     System.out.println(entry.getValue());
                     bridgeHandler.sendMessage(entry.getValue());
@@ -145,7 +145,7 @@ public class OpenWMSHandler extends BaseThingHandler implements DeviceMessageLis
                         // logger.debug("Checking OpenWMS BLIND connection, thing status = {}", thing.getStatus());
                         logger.debug("Checking OpenWMS connection, thing label = {}, thing status = {}",
                                 thing.getLabel(), thing.getStatus());
-                        Map<String, String> msg = OpenWMSMessageFactory.createMessage("GETSTATUS", thing);
+                        Map<String, String> msg = OpenWMSMessageFactory.createMessage("GETSTATUS", thing, null);
                         for (Entry<String, String> entry : msg.entrySet()) {
                             System.out.println(entry.getValue());
                             bridgeHandler.sendMessage(entry.getValue());

--- a/src/main/java/org/openhab/binding/openwms/messages/OpenWMSGetResponse.java
+++ b/src/main/java/org/openhab/binding/openwms/messages/OpenWMSGetResponse.java
@@ -327,21 +327,33 @@ public class OpenWMSGetResponse {
 
             case CHANNEL_SHUTTER:
                 if (position != null) {
-                    return new PercentType(position);
+                    try {
+                        return new PercentType(position);
+                    } catch(IllegalArgumentException e) {
+                        return null;
+                    }
                 } else {
                     return null;
                 }
 
             case CHANNEL_VALANCE1:
                 if (valance1 != null) {
-                    return new PercentType(valance1);
+                    try {
+                        return new PercentType(valance1);
+                    } catch(IllegalArgumentException e) {
+                        return null;
+                    }
                 } else {
                     return null;
                 }
 
             case CHANNEL_VALANCE2:
                 if (valance2 != null) {
-                    return new PercentType(valance2);
+                    try {
+                        return new PercentType(valance2);
+                    } catch(IllegalArgumentException e) {
+                        return null;
+                    }
                 } else {
                     return null;
                 }

--- a/src/main/java/org/openhab/binding/openwms/messages/OpenWMSGetResponse.java
+++ b/src/main/java/org/openhab/binding/openwms/messages/OpenWMSGetResponse.java
@@ -122,9 +122,13 @@ public class OpenWMSGetResponse {
                         case "01000003": // position WMS Motor
                             // TODO
                             setPosition(String.valueOf(Integer.parseInt(payload.substring(0, 2), 16) / 2));
+                            setValance1(String.valueOf(Integer.parseInt(payload.substring(4, 6), 16) / 2));
+                            setValance2(String.valueOf(Integer.parseInt(payload.substring(6, 8), 16) / 2));
                             break;
                         case "01000005": // position WMS Motor
                             setPosition(String.valueOf(Integer.parseInt(payload.substring(0, 2), 16) / 2));
+                            setValance1(String.valueOf(Integer.parseInt(payload.substring(4, 6), 16) / 2));
+                            setValance2(String.valueOf(Integer.parseInt(payload.substring(6, 8), 16) / 2));
                             break;
                         case "26000046": // Current clock timer settings
                             // TODO
@@ -180,7 +184,8 @@ public class OpenWMSGetResponse {
     }
 
     public void setPosition(String position) {
-        this.position = position;
+        if (!position.toUpperCase().equals("FF"))
+            this.position = position;
     }
 
     public String getDeviceId() {
@@ -214,7 +219,8 @@ public class OpenWMSGetResponse {
     }
 
     public void setValance1(String valance1) {
-        this.valance1 = valance1;
+        if (!valance1.toUpperCase().equals("FF"))
+            this.valance1 = valance1;
     }
 
     public String getValance2() {
@@ -222,7 +228,8 @@ public class OpenWMSGetResponse {
     }
 
     public void setValance2(String valance2) {
-        this.valance2 = valance2;
+        if (!valance2.toUpperCase().equals("FF"))
+            this.valance2 = valance2;
     }
 
     public String getWindspeed() {
@@ -325,6 +332,20 @@ public class OpenWMSGetResponse {
                     return null;
                 }
 
+            case CHANNEL_VALANCE1:
+                if (valance1 != null) {
+                    return new PercentType(valance1);
+                } else {
+                    return null;
+                }
+
+            case CHANNEL_VALANCE2:
+                if (valance2 != null) {
+                    return new PercentType(valance2);
+                } else {
+                    return null;
+                }
+
             case CHANNEL_WINDSPEED:
                 if (windspeed != null) {
                     return new DecimalType(windspeed);
@@ -371,7 +392,7 @@ public class OpenWMSGetResponse {
     }
 
     public void convertFromState(String channelId, Type type) {
-        if (CHANNEL_SHUTTER.equals(channelId)) {
+        if (CHANNEL_SHUTTER.equals(channelId) || CHANNEL_VALANCE1.equals(channelId) || CHANNEL_VALANCE2.equals(channelId)) {
             if (type instanceof OpenClosedType) {
                 command = (type == OpenClosedType.CLOSED ? Commands.CLOSE : Commands.OPEN);
             } else if (type instanceof UpDownType) {

--- a/src/main/resources/ESH-INF/thing/blind.xml
+++ b/src/main/resources/ESH-INF/thing/blind.xml
@@ -18,6 +18,8 @@
         <channels>
             <channel id="command" typeId="command" />
             <channel id="shutter" typeId="shutter" />
+            <channel id="valance1" typeId="valance1" />
+            <channel id="valance2" typeId="valance2" />
             <channel id="dimminglevel" typeId="dimminglevel" />
             
            

--- a/src/main/resources/ESH-INF/thing/channels.xml
+++ b/src/main/resources/ESH-INF/thing/channels.xml
@@ -66,6 +66,18 @@
         <description>Open/Close shutter/blind</description>
     </channel-type>
 
+    <channel-type id="valance1">
+        <item-type>Rollershutter</item-type>
+        <label>Valance 1</label>
+        <description>Open/Close valance 1</description>
+    </channel-type>
+
+    <channel-type id="valance2">
+        <item-type>Rollershutter</item-type>
+        <label>Valance 2</label>
+        <description>Open/Close valance 2</description>
+    </channel-type>
+
     <channel-type id="venetianBlind">
         <item-type>Dimmer</item-type>
         <label>Venetian Blind</label>


### PR DESCRIPTION
This pull requests adds two rollershutter channels to control valance channels 1 and 2. Also, I included the status request command after the stop command as the shutter/marquee/valance etc. will have stopped in an arbitrary position and I do not see any situation in which it would not be a good idea to receive this new position.

I think that this pull request is save to be merged, but there are a few things I would like to note here:

- I only have a marquee with a valance (I hope that this is the correct term and not just the result of a bunch of German dudes using the same dictionary to translate "volant"). So, I could not test the second valance channel and I could not check if anything might break for users without a valance. However, I do not see how any code should be executed differently if it is not being used.
- I have not added the "angle" channel (venetian blinds?) although it might be straight forward to do so, too. I simply do not have such a device and do not know the mapping of the values.
- I tried to add the new channels according to the structure of the binding. However, I am not sure if this is the best approach. You might want to think about restructuring the binding a bit if more channels are added. I have added the (OpenHAB) channel as a parameter to all commands but the set of "internal" commands will grow and might become a bit "unwieldy", so maybe the individual commands are better represented by specific functions (maybe within a polymorphic message factory). Just a thought, don't worry too much about it :)

Besides that, thanks for the binding. For now I think it has everything I need - that is until summer, when I actually can use the marquee to find some details to work on.